### PR TITLE
fix: route telemetry service extraArgs to telemetryServices

### DIFF
--- a/migrate-v3-to-v4.js
+++ b/migrate-v3-to-v4.js
@@ -12,7 +12,7 @@ const TELEMETRY_SERVICE_KEYS = ["node-exporter", "windows-exporter", "kube-state
 const DEPLOYMENT_FIELDS = new Set([
     "deploy", "resources", "tolerations", "image", "imagePullSecrets",
     "nameOverride", "fullnameOverride", "replicas", "autosharding",
-    "podAnnotations", "rbac",
+    "podAnnotations", "rbac", "extraArgs",
 ]);
 
 // Extra fields specific to opencost that go to telemetryServices (not costMetrics)


### PR DESCRIPTION
In v3, `clusterMetrics.node-exporter.extraArgs` provides additional arguments to the sub-chart workload. In v4, deployment of these backing services moved under `telemetryServices.<service>` [1]. The migrator was routing `extraArgs` to `hostMetrics.linuxHosts` (a feature configuration path), where the field is not recognized and silently dropped.

Add `extraArgs` to DEPLOYMENT_FIELDS so it is routed to `telemetryServices.<service>.extraArgs`.

[1] https://grafana.com/docs/grafana-cloud/monitor-infrastructure/kubernetes-monitoring/configuration/helm-chart-config/helm-chart/migrate-helm-chart/